### PR TITLE
Added Draft Calendar responsiveness styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -247,6 +247,9 @@ text-decoration: none;
 	top: 50%;
 	background-color: #ffffff;
 	color: #333333;
+	display: flex;
+	justify-content: center;
+	align-items: flex-start;
 }
 
 .calendar h1, .calendar h2{
@@ -263,7 +266,7 @@ text-decoration: none;
 
 .calendar .col{
 	position: relative;
-	float: left;
+	/* float: left; */
 	height: 100%;
 }
 
@@ -467,4 +470,29 @@ text-decoration: none;
 
 .calendar .days .disabled {
 	pointer-events: none;
+}
+
+/* Calendar Responsiveness */
+@media screen and (max-width: 835px) {
+	.calendar {
+		/* position: absolute; */
+		flex-wrap: wrap;
+		width: 90%;
+		height: 110%;
+		top: 300px;
+		left: 55%;
+	}
+	.calendar .col{
+		/* float: none; */
+		/* position: relative; */
+	}
+	.calendar .leftCol {
+		width: 80%;
+		height: 425px;
+	}
+	.calendar .rightCol {
+		width: 80%;
+		height: 100%;
+
+	}
 }

--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -77,7 +77,7 @@
                     <li><a href="#" title="Say" data-value="6">Sat</a></li>
                     <li><a href="#" title="Sun" data-value="7">Sun</a></li>
                 </ul>
-                <div class="clearfix"></div>
+                <!-- <div class="clearfix"></div> -->
                 
                 <!--calendar functionality -->
                 <ul class="days" id="days">


### PR DESCRIPTION
- Converted Calendar to Flexbox from floats
- Added Media query (look at end of the styles.css file) to wrap flex container (calendar) so that the col left spans whole row and the col right wraps below and spans whole 2nd row.

![Recording 2022-09-04 at 15 26 14](https://user-images.githubusercontent.com/29828039/188330443-6daa755d-378d-46b4-a659-bb1212077ebb.gif)
